### PR TITLE
Add "Connection" header to close connection.

### DIFF
--- a/Twitter.cpp
+++ b/Twitter.cpp
@@ -45,6 +45,7 @@ bool Twitter::post(const char *msg)
 		client.print("Content-Length: ");
 		client.println(strlen(msg)+strlen(token)+14);
 		client.println("Host: " LIB_DOMAIN);
+		client.println("Connection: close");
 		client.println();
 		client.print("token=");
 		client.print(token);


### PR DESCRIPTION
Without this header, calls to wait() would hang.
This seems to have just started happening recently, not sure why. Perhaps Google changed something.